### PR TITLE
calling #to_hash on nil will return nil and not an empty hash.

### DIFF
--- a/lib/hash_kit/helper.rb
+++ b/lib/hash_kit/helper.rb
@@ -15,7 +15,11 @@ module HashKit
       end
     end
 
+    # Convert an object to a hash representation of its instance variables.
+    # @return [Hash] if the object is not nil, otherwise nil is returned.
     def to_hash(obj)
+      return nil unless obj
+
       hash = {}
       obj.instance_variables.each do |key|
         hash[key[1..-1].to_sym] = deeply_to_hash(obj.instance_variable_get(key))

--- a/spec/hash_kit/helper_spec.rb
+++ b/spec/hash_kit/helper_spec.rb
@@ -154,6 +154,12 @@ RSpec.describe HashKit::Helper do
         entity.entity_array = [child_entity, child_entity]
       end
     end
+   
+    context 'entity to convert is nil' do
+      it 'returns nil' do
+        expect(subject.to_hash(nil)).to eq nil
+      end
+    end
 
     context 'single layer entity' do
       it 'should create a hash' do


### PR DESCRIPTION
When the origin entity is nil, it will no longer return an empty hash.  This caused values to be stored as an `{}` in the DB.  There was already a check if nested values were nil, but not the starting entity.
