### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Publish to RubyGems
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,20 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Run tests
         run: |
-          docker-compose up -d
+          docker compose up -d
           docker exec gem_test_runner bash -c "cd gem_src && bundle install && bundle exec rspec"
-
-      - name: Code Coverage
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          debug: true
-          coverageLocations: |
-            ${{github.workspace}}/coverage/coverage.json:simplecov
-          prefix: /gem_src
-          verifyDownload: true

--- a/benchmark/indifferent_bench.rb
+++ b/benchmark/indifferent_bench.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'benchmark/ips'
+require 'hash_kit'
+
+helper = HashKit::Helper.new
+
+# ---------------------------------------------------------------------------
+# Hash builders – every benchmark iteration gets a fresh hash so that
+# default_proc assignment is always exercised (no short-circuit).
+# ---------------------------------------------------------------------------
+
+def build_small_flat_hash
+  { 'name' => 'Alice', 'age' => 30, 'active' => true }
+end
+
+def build_large_flat_hash(n = 100)
+  (0...n).each_with_object({}) { |i, h| h["key_#{i}"] = "value_#{i}" }
+end
+
+def build_nested_hash(depth = 5)
+  hash = { 'leaf' => 'value' }
+  depth.times { |i| hash = { "level_#{i}" => hash, "sibling_#{i}" => 'data' } }
+  hash
+end
+
+def build_hash_with_arrays
+  {
+    'users' => [
+      { 'name' => 'Alice', 'roles' => [{ 'id' => 1, 'name' => 'admin' }] },
+      { 'name' => 'Bob',   'roles' => [{ 'id' => 2, 'name' => 'editor' }] },
+      { 'name' => 'Carol', 'roles' => [{ 'id' => 3, 'name' => 'viewer' }] }
+    ],
+    'meta' => { 'page' => 1, 'total' => 3 }
+  }
+end
+
+def build_large_nested_hash(width = 20, depth = 4)
+  return (0...width).each_with_object({}) { |i, h| h["key_#{i}"] = "val_#{i}" } if depth == 0
+
+  (0...width).each_with_object({}) do |i, h|
+    h["node_#{i}"] = build_large_nested_hash(width, depth - 1)
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Benchmark suite
+# ---------------------------------------------------------------------------
+
+puts 'HashKit::Helper#indifferent! benchmark'
+puts "Ruby #{RUBY_VERSION} / benchmark-ips #{Benchmark::IPS::VERSION}"
+puts '=' * 60
+
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+
+  # --- Scenario 1: small flat hash (3 keys) ---
+  x.report('small flat hash (3 keys)') do
+    helper.indifferent!(build_small_flat_hash)
+  end
+
+  # --- Scenario 2: large flat hash (100 keys) ---
+  x.report('large flat hash (100 keys)') do
+    helper.indifferent!(build_large_flat_hash(100))
+  end
+
+  # --- Scenario 3: deeply nested hash (5 levels) ---
+  x.report('nested hash (depth=5)') do
+    helper.indifferent!(build_nested_hash(5))
+  end
+
+  # --- Scenario 4: hash containing arrays of hashes ---
+  x.report('hash with arrays') do
+    helper.indifferent!(build_hash_with_arrays)
+  end
+
+  # --- Scenario 5: large nested hash (wide + deep) ---
+  x.report('large nested (10x3)') do
+    helper.indifferent!(build_large_nested_hash(10, 3))
+  end
+
+  # --- Scenario 6: many sequential calls on small hashes ---
+  x.report('50x sequential small hashes') do
+    50.times { helper.indifferent!(build_small_flat_hash) }
+  end
+
+  # --- Scenario 7: many sequential calls on medium hashes ---
+  x.report('50x sequential nested hashes') do
+    50.times { helper.indifferent!(build_nested_hash(3)) }
+  end
+
+  x.compare!
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gem_test_runner:
-    image: ruby:2.7.8-bullseye
+    image: ruby:4
     container_name: gem_test_runner
     command: bash -c "while true; do echo 'Container is running...'; sleep 2; done"
     volumes:
-        - ./:/gem_src
+      - ./:/gem_src

--- a/hash_kit.gemspec
+++ b/hash_kit.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'simplecov'
 end

--- a/hash_kit.gemspec
+++ b/hash_kit.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hash_kit/version'
 
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'benchmark-ips', '~> 2.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'

--- a/hash_kit.gemspec
+++ b/hash_kit.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 3.0.0'
+
   spec.add_development_dependency 'benchmark-ips', '~> 2.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'

--- a/lib/hash_kit/helper.rb
+++ b/lib/hash_kit/helper.rb
@@ -3,6 +3,16 @@
 module HashKit
   # Hash kit Helper class
   class Helper
+    INDIFFERENT_PROC = proc do |h, k|
+      if h.key?(k.to_s)
+        h[k.to_s]
+      elsif h.key?(k.to_sym)
+        h[k.to_sym]
+      else
+        nil
+      end
+    end
+
     # This method is called to make a hash allow indifferent access (it will
     # accept both strings & symbols for a valid key).
     def indifferent!(hash)
@@ -10,15 +20,7 @@ module HashKit
 
       # Set the default proc to allow the key to be either string or symbol if
       # a matching key is found.
-      hash.default_proc = proc do |h, k|
-        if h.key?(k.to_s)
-          h[k.to_s]
-        elsif h.key?(k.to_sym)
-          h[k.to_sym]
-        else
-          nil
-        end
-      end
+      hash.default_proc = INDIFFERENT_PROC
 
       # Recursively process any child hashes
       hash.each do |key,value|

--- a/lib/hash_kit/helper.rb
+++ b/lib/hash_kit/helper.rb
@@ -4,12 +4,16 @@ module HashKit
   # Hash kit Helper class
   class Helper
     INDIFFERENT_PROC = proc do |h, k|
-      if h.key?(k.to_s)
-        h[k.to_s]
-      elsif h.key?(k.to_sym)
-        h[k.to_sym]
+      case k
+      when Symbol
+        # Symbol#name returns a frozen string without allocating (Ruby 3.0+)
+        str = k.name
+        h[str] if h.key?(str)
+      when String
+        sym = k.to_sym
+        h[sym] if h.key?(sym)
       else
-        nil
+        h[k.to_s]
       end
     end
 
@@ -23,13 +27,12 @@ module HashKit
       hash.default_proc = INDIFFERENT_PROC
 
       # Recursively process any child hashes
-      hash.each do |key,value|
-        unless hash[key].nil?
-          if hash[key].is_a?(Hash)
-            indifferent!(hash[key])
-          elsif hash[key].is_a?(Array)
-            indifferent_array!(hash[key])
-          end
+      hash.each_value do |value|
+        case value
+        when Hash
+          indifferent!(value)
+        when Array
+          indifferent_array!(value)
         end
       end
 
@@ -40,9 +43,10 @@ module HashKit
       return unless array.is_a?(Array)
 
       array.each do |i|
-        if i.is_a?(Hash)
+        case i
+        when Hash
           indifferent!(i)
-        elsif i.is_a?(Array)
+        when Array
           indifferent_array!(i)
         end
       end


### PR DESCRIPTION
## Improvement 1: Use a single proc instance

Instead of creating a new `proc` object every time `#indifferent!` is called, it now references a constant. This cuts down on instantiation times.

## Improvement 2

- Require at least Ruby 3 so we can use Symbol#name (doesn't allocate a string each time)
- Use case/when for faster type dispatch
- Reduce calls to #to_s
- Use #each_value instead of #each and getting the value

## Benchmarks

The PR adds a benchmark suite to support the improvements.

It is measuring iterations per second (higher is better)

|              bench                |        before        |   Improvement 1  |   Improvement 2  |
|-----------------------------------|----------------------|------------------|------------------|
| small flat hash (3 keys)          |       783.550k       |     994.353k     |      1.754M      |
| large flat hash (100 keys)        |        13.494k       |      13.540k     |     17.531k      |
| nested hash (depth=5)             |       127.639k       |     164.469k     |    227.875k      |
| hash with arrays                  |       112.105k       |     149.360k     |    226.160k      |
| large nested (10x3)               |        118.661       |      127.363     |     162.544      |
| 50x sequential small hashes       |        15.522k       |      20.055k     |     36.721k      |
| 50x sequential nested hashes      |         3.980k       |       5.303k     |      7.096k      |


Also modernises CI to a updated Ruby version and all that.